### PR TITLE
Fix some typos and rephrase some sentences in the user guide

### DIFF
--- a/resources/templates/md/pages/user-guide.md
+++ b/resources/templates/md/pages/user-guide.md
@@ -7,7 +7,7 @@
 
 All the examples below are <strong>interactive</strong>. Click the button below
 each example evaluate the expression against the live, <a
-href="http://public.yetibot.com">public Yetibot instance</a> using the GraphQL
+href="https://public.yetibot.com">public Yetibot instance</a> using the GraphQL
 API.
 
 ## Basics
@@ -96,8 +96,8 @@ syntax lets you embed any level of nesting:
 !echo $(echo $(echo Yetibot) is) alive
 ```
 
-These examples are necessarily simplistic, but when you start piecing together
-more complex commands that fetch data the ability to arbitrarily nest
+These examples are necessarily simplistic but when you start piecing together
+more complex commands that fetch data, the ability to arbitrarily nest
 expressions provides tremendous power.
 
 ## Xargs
@@ -155,7 +155,7 @@ They're super powerful but can be easily be abused.
 
 ## Data
 
-Yeibot commands by default return a pretty-printed response for human
+Yetibot commands by default return a pretty-printed response for human
 consumption, but the underlying data is preserved and accessible as well.
 
 ```yetibot
@@ -174,7 +174,7 @@ expression.
 ## Eval
 
 The `eval` command runs arbitrary Clojure against the Yetibot process itself, so
-it's by definition very insecure. Because of this, it's only allowed to by run
+it's by definition very insecure. Because of this, it's only allowed to be run
 by users that have been pre-configured to have access.
 
 It can be a fun way of poking at otherwise-unavailable state inside Yetibot.
@@ -195,7 +195,7 @@ Yetibot serves a GraphQL endpoint as part of its web app. The public Yetibot
 instance is accessible at
 [https://public.yetibot.com/graphql](https://public.yetibot.com/graphql).
 
-For example, to inspect the configured adapters run a query with a GraphQL
+For example, to inspect the configured adapters, run the following query with a GraphQL
 client:
 
 ```graphql


### PR DESCRIPTION
hey guys,

this PR fixes some typos in the _user guide_. I have also rephrased one or two sentences either by adding puncutation or entire words to help clarify the user guide.

This is some kind of warmups before I dive into the `Yetibot` code base so feel free to let me know if you want me to change something. I hope I will be able to contribute as much as I can to the project.

very welcoming project, by the way ;-)
thanks a lot for the opportunity ^^...
