### PR TITLE
Updated versions of Clojure and lein-ring plugin, resolving crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .lein-failures
 /resources/public/
 node_modules/
+/resources/templates/.sass-cache

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ pom.xml.asc
 .lein-failures
 /resources/public/
 node_modules/
-/resources/templates/.sass-cache

--- a/project.clj
+++ b/project.clj
@@ -3,14 +3,14 @@
             :url "https://github.com/lacarmen/cryogen"
             :license {:name "Eclipse Public License"
                       :url "http://www.eclipse.org/legal/epl-v10.html"}
-            :dependencies [[org.clojure/clojure "1.8.0"]
+            :dependencies [[org.clojure/clojure "1.10.0"]
                            [ring/ring-devel "1.6.3"]
                            [compojure "1.6.0"]
                            [org.webjars.npm/bulma "0.6.2"]
                            [ring-server "0.5.0"]
                            [cryogen-markdown "0.1.7"]
                            [cryogen-core "0.1.65"]]
-            :plugins [[lein-ring "0.9.7"]]
+            :plugins [[lein-ring "0.12.5"]]
             :main cryogen.core
             :ring {:init cryogen.server/init
                    :handler cryogen.server/handler})


### PR DESCRIPTION
* Updated to Clojure `1.10.0`, same as yetibot.
* Updated lein-ring plugin to `0.12.5`.  The version in yetibot, `0.12.4`, did not resolve the crash on launch.

I didn't investigate updating other deps.