### PR TITLE
example of how to use `parse-opts` with YB commands

### DIFF
--- a/resources/templates/md/pages/dev-guide.md
+++ b/resources/templates/md/pages/dev-guide.md
@@ -579,6 +579,50 @@ for a full example.
 1. Using `command-execution-info`
 1. Mocking with Midje
 
+## Parsing command arguments
+
+Fancy words go here for `parse-opts`. Blah Blah Blah.
+
+Here's an example command that would a `name` argument:
+
+```clojure
+(ns mycompany.plugins.commands.hello
+  (:require [yetibot.core.hooks :refer [cmd-hook]]
+            [clojure.tools.cli :refer [parse-opts]]
+            [clojure.string :refer [split]]))
+
+(def cli-options [["-n" "--name NAME"]])
+
+(defn hello-cmd
+  "hello # say hello
+   
+   Personalize the hello to a name:
+   -n --name <name>"
+  [{:keys [match]}]
+  (let [{options :options} (parse-opts (split match #" ") cli-options)]
+    (if (:name options)
+      ; enthusiastically say hello to the name
+      (str "Hello " (:name options) "!")
+      ; otherwise just greet
+      "Greetings.")))
+
+(cmd-hook #"hello"
+          _ hello-cmd)
+```
+
+An example invocation would look like:
+
+```
+!hello -n Bob
+Hello Bob!
+
+!hello
+Greetings.
+```
+
+For a more elaborate example of using `parse-opts`, take a look at
+[Yetibot's history command](https://github.com/yetibot/yetibot.core/blob/master/src/yetibot/core/commands/history.clj).
+
 ## Working with the database
 
 ## Parser

--- a/resources/templates/md/pages/dev-guide.md
+++ b/resources/templates/md/pages/dev-guide.md
@@ -579,11 +579,11 @@ for a full example.
 1. Using `command-execution-info`
 1. Mocking with Midje
 
-## Parsing command arguments
+## Parsing command options
 
-Fancy words go here for `parse-opts`. Blah Blah Blah.
+A Yetibot command can parse options, much like you would encounter using common CLI tools. This is made possible by using the `clojure.tools.cli` library and related `parse-opts` function.
 
-Here's an example command that would a `name` argument:
+Here's an example command that would parse a `name` option:
 
 ```clojure
 (ns mycompany.plugins.commands.hello
@@ -596,7 +596,7 @@ Here's an example command that would a `name` argument:
 (defn hello-cmd
   "hello # say hello
    
-   Personalize the hello to a name:
+   Personalize the hello:
    -n --name <name>"
   [{:keys [match]}]
   (let [{options :options} (parse-opts (split match #" ") cli-options)]


### PR DESCRIPTION
some YB devs might be coming from Errbot -- and may have used Python's `argparse` .. Thought it would be a good idea to show a similar example in YB, using `parse-opts`

Wasn't entirely sure where to put it, but after all the other "introductory" command development docs seemed logical

Thanks for reviewing and always open to feedback/changes
