### PR TITLE
adding a simple observer example to the DEV guide

### DIFF
--- a/resources/templates/md/pages/dev-guide.md
+++ b/resources/templates/md/pages/dev-guide.md
@@ -623,6 +623,41 @@ Greetings.
 For a more elaborate example of using `parse-opts`, take a look at
 [Yetibot's history command](https://github.com/yetibot/yetibot.core/blob/master/src/yetibot/core/commands/history.clj).
 
+## Observing chat messages
+
+Yetibot can observe all chat messages in channels it's a member of, and react to them should they meet defined patterns. Typical use cases want to proactively "push" information to users, versus waiting to respond to a command's invocation. For example, an organization might want to proactively "push" a new URL for commonly used Web site.
+
+Here's an example observer function:
+
+```clojure
+(ns myeti.plugins.observers.example
+  (:require [yetibot.core.hooks :refer [obs-hook]]
+            [yetibot.core.chat :refer [chat-data-structure]]))
+
+(defn respond []
+  ;; the chat-data-structure function can best be thought of
+  ;; as a "send message" function, allowing for multiple responses
+  (chat-data-structure "The new URL for old.example.com is new.example.com"))
+
+;; observer all chat messages
+(obs-hook #{:message}
+          (fn [event-info]
+            ;; if the body of the message contains the URL "old.example.com",
+            ;; run "respond" function
+            (if-let [m (re-find #"old\.example\.com" (:body event-info))]
+              (respond))))
+```
+
+An example invocation might look like:
+
+```
+Frank: Jeff, I think the Web site you want is old.example.com
+Yetibot: The new URL for old.example.com is new.example.com
+```
+
+For a more elaborate example of using `obs-hook`, take a look at
+[Yetibot's karma observer](https://github.com/yetibot/yetibot.core/blob/master/src/yetibot/core/observers/karma.clj).
+
 ## Working with the database
 
 Data schemas in Yetibot are designed to be idempotent. Because of this, we apply

--- a/resources/templates/md/pages/dev-guide.md
+++ b/resources/templates/md/pages/dev-guide.md
@@ -625,12 +625,12 @@ For a more elaborate example of using `parse-opts`, take a look at
 
 ## Observing chat messages
 
-Yetibot can observe all chat messages in channels it's a member of, and react to them should they meet defined patterns. Typical use cases want to proactively "push" information to users, versus waiting to respond to a command's invocation. For example, an organization might want to proactively "push" a new URL for commonly used Web site.
+Yetibot can observe all chat messages in channels it's a member of, and react to them should they meet defined patterns. Typical use cases want to proactively "push" information to users, versus waiting to respond to a command's invocation. For example, an organization might want to proactively "push" a new URL for a commonly used Web site.
 
 Here's an example observer function:
 
 ```clojure
-(ns myeti.plugins.observers.example
+(ns mycompany.plugins.observers.example
   (:require [yetibot.core.hooks :refer [obs-hook]]
             [yetibot.core.chat :refer [chat-data-structure]]))
 
@@ -639,7 +639,7 @@ Here's an example observer function:
   ;; as a "send message" function, allowing for multiple responses
   (chat-data-structure "The new URL for old.example.com is new.example.com"))
 
-;; observer all chat messages
+;; observe all chat messages
 (obs-hook #{:message}
           (fn [event-info]
             ;; if the body of the message contains the URL "old.example.com",
@@ -657,6 +657,8 @@ Yetibot: The new URL for old.example.com is new.example.com
 
 For a more elaborate example of using `obs-hook`, take a look at
 [Yetibot's karma observer](https://github.com/yetibot/yetibot.core/blob/master/src/yetibot/core/observers/karma.clj).
+
+Yetibot is prepackaged with the `!obs` command, which is the runtime equivalent to code-based observers. While very similar to code-based observers, they are user driven customizations that don't necessarily belong in the code base. You can learn more about them here: [User Guide: Observers](/user-guide#observers)
 
 ## Working with the database
 


### PR DESCRIPTION
i am not in love with the styling of the example invocation (oddly highlighted URL) -- so anything you can recommend there would be appreciated

the reasoning behind this is because the concept of "observers" ("listeners" in Hubot) is very powerful, and i didn't see any great example HOWTOs in the DEV guide

feedback is always welcomed
